### PR TITLE
Expose HTTP endpoint for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY runn_sync.py .
 
 # Define el comando por defecto que se ejecutará cuando el contenedor arranque
-CMD [ "python3", "runn_sync.py" ]
+CMD [ "python3", "runn_sync.py", "--serve" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-cloud-bigquery
 requests
+Flask


### PR DESCRIPTION
## Summary
- add a Flask-based HTTP server so Cloud Run can trigger the sync through /run and expose health checks
- refactor the CLI parser into reusable helpers shared by both HTTP and command-line flows
- update the container image to start the service mode by default and include the new dependency

## Testing
- RUNN_API_TOKEN=dummy BQ_PROJECT=test python -m compileall runn_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f9ae8b8c8325969150165fd791c0